### PR TITLE
Capitalize .JPG extension in moonevent image_tag source

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -12,7 +12,7 @@
 
   </div>
   <div class="column">
-    <%= image_tag "moonevent.jpg",:class=>"image"%>
+    <%= image_tag "moonevent.JPG",:class=>"image"%>
     <div class="overlay">Moon</div>
   </div>
   <div class="column">


### PR DESCRIPTION
On case-sensitive filesystems (Windows/Mac have case-insensitive filesystems; on Linux it's usually case-sensitive) the web app can't find `moonevent.jpg` because it's called `moonevent.JPG`, leading to the following crash when trying to load the main page:

![2019-09-10_17:30:20](https://user-images.githubusercontent.com/8890878/64652731-8d703c00-d3f2-11e9-92af-942665133f35.png)

This (super tiny) pull request renames the `image_tag`'s source to match with the real file name.

Note: I haven't checked if there are more problems like this, but we'll need to fix them if we want to deploy to a Linux server e.g. on Heroku or AWS